### PR TITLE
Prepare for 0.1.0 release 2

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -98,6 +98,10 @@ jobs:
 
       - name: Build jvm-getter for ${{ matrix.name }} with the ${{ matrix.profile }} profile
         run: cargo build -p jvm-getter --target ${{ matrix.target }} --profile ${{ matrix.profile }}
+        env:
+          RUSTFLAGS: "-D warnings"
 
       - name: Run Cargo Clippy for ${{ matrix.name }} with the ${{ matrix.profile }} profile
         run: cargo clippy -p jvm-getter --target ${{ matrix.target }} --profile ${{ matrix.profile }}
+        env:
+          RUSTFLAGS: "-D warnings"

--- a/jvm-getter/src/lib.rs
+++ b/jvm-getter/src/lib.rs
@@ -35,7 +35,7 @@ mod windows;
 use jni_sys::{jint, jsize, JavaVM};
 
 /// The function pointer type of `JNI_GetCreatedJavaVMs()`.
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, non_snake_case)]
 pub type JNI_GetCreatedJavaVMs =
     unsafe extern "system" fn(vmBuf: *mut *mut JavaVM, bufLen: jsize, nVMs: *mut jsize) -> jint;
 


### PR DESCRIPTION
A follow-up PR for #4.

- Fixed potential warnings in `lib.rs`.
- Set `RUSTFLAGS=-D warnings` during CI builds.