### PR TITLE
Update `jni-sys` to `0.4.1` and `jni` to `0.22.4`

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         profile: [dev, release]
-        rust-version: ["1.73", "1.78", "1.83", "1.88"]
+        rust-version: ["1.76", "1.78", "1.83", "1.88"]
         target:
           # Android Targets
           - aarch64-linux-android

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to manually handle Java-specific logic for Android. To learn about the strategy 
 also available on Desktop platforms, including Windows, macOS, and Linux.
 
 [`JNI_GetCreatedJavaVMs()`]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html#JNI_GetCreatedJavaVMs
-[`find_jni_get_created_java_vms()`]: ./jvm-getter/src/lib.rs#L42-60
+[`find_jni_get_created_java_vms()`]: ./jvm-getter/src/lib.rs#L42-L60
 
 ## How to use
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to manually handle Java-specific logic for Android. To learn about the strategy 
 also available on Desktop platforms, including Windows, macOS, and Linux.
 
 [`JNI_GetCreatedJavaVMs()`]: https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html#JNI_GetCreatedJavaVMs
-[`find_jni_get_created_java_vms()`]: ./jvm-getter/src/lib.rs#L42-L60
+[`find_jni_get_created_java_vms()`]: ./jvm-getter/src/lib.rs#L42-60
 
 ## How to use
 
@@ -60,8 +60,7 @@ pub fn vm() -> &'static JavaVM {
             panic!("no JavaVM was found by JNI_GetCreatedJavaVMs");
         }
 
-        let vm = unsafe { JavaVM::from_raw(vm.assume_init()) };
-        vm.expect("JNI_GetCreatedJavaVMs returned nullptr")
+        unsafe { JavaVM::from_raw(vm.assume_init()) }
     })
 }
 ```

--- a/jvm-getter-tests/Cargo.lock
+++ b/jvm-getter-tests/Cargo.lock
@@ -149,14 +149,8 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.14",
+ "thiserror",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -304,25 +298,52 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jvm-getter"
@@ -474,6 +495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +593,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,31 +667,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.14",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -858,13 +884,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -882,21 +905,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -921,7 +929,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -931,12 +939,6 @@ dependencies = [
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -952,12 +954,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -967,12 +963,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1000,12 +990,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1015,12 +999,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1036,12 +1014,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1051,12 +1023,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/jvm-getter-tests/Cargo.toml
+++ b/jvm-getter-tests/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/commonMain/rust/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-jni = "0.21"
+jni = "0.22.4"
 jvm-getter = { path = "../jvm-getter", default-features = false }
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread"] }
 uniffi = { version = "=0.29.3", features = ["tokio"] }

--- a/jvm-getter-tests/src/commonMain/rust/lib.rs
+++ b/jvm-getter-tests/src/commonMain/rust/lib.rs
@@ -3,9 +3,11 @@
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
 
-use jni::JNIEnv;
-use jni::objects::{JClass, JValue, JValueGen};
+use jni::objects::{JClass, JString, JValue};
+use jni::strings::JNIString;
 use jni::sys::{JNI_OK, JavaVM};
+use jni::{Env, jni_sig, jni_str};
+use uniffi::deps::anyhow;
 
 #[uniffi::export]
 pub fn find_jni_get_created_java_vms() -> u64 {
@@ -24,21 +26,27 @@ pub fn get_java_vm() -> u64 {
 #[uniffi::export]
 pub fn get_simple_object_field_value_without_jni_on_load() -> Option<String> {
     let java_vm = unsafe { get_java_vm_impl()? };
-    let java_vm = unsafe { jni::JavaVM::from_raw(java_vm).ok()? };
-    let mut env = java_vm.attach_current_thread_as_daemon().ok()?;
-
-    #[allow(non_snake_case)]
-    let SimpleObject = find_class_via_env(&mut env, "dev/gobley/jvmgetter/tests/SimpleObject")?;
-    #[allow(non_snake_case)]
-    let simple_value = env
-        .get_static_field(SimpleObject, "simpleValue", "Ljava/lang/String;")
-        .ok()?;
-    let JValueGen::Object(simple_value) = simple_value else {
-        return None;
-    };
-    let simple_value = simple_value.into();
-    let simple_value = env.get_string(&simple_value).ok()?;
-    Some(simple_value.to_string_lossy().to_string())
+    let java_vm = unsafe { jni::JavaVM::from_raw(java_vm) };
+    java_vm
+        .attach_current_thread(|mut env| {
+            #[allow(non_snake_case)]
+            let Some(SimpleObject) =
+                find_class_via_env(&mut env, "dev/gobley/jvmgetter/tests/SimpleObject")
+            else {
+                anyhow::bail!("SimpleObject not found");
+            };
+            #[allow(non_snake_case)]
+            let simple_value = env
+                .get_static_field(
+                    SimpleObject,
+                    jni_str!("simpleValue"),
+                    jni_sig!("Ljava/lang/String;"),
+                )?
+                .l()?;
+            let simple_value = JString::cast_local(env, simple_value)?;
+            Ok(simple_value.to_string())
+        })
+        .ok()
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -68,8 +76,8 @@ pub async fn get_simple_object_field_value_without_jni_on_load_from_rust_thread(
     value
 }
 
-fn find_class_via_env<'a>(env: &mut JNIEnv<'a>, class_name: &str) -> Option<JClass<'a>> {
-    if let Ok(class) = env.find_class(class_name) {
+fn find_class_via_env<'a>(env: &mut Env<'a>, class_name: &str) -> Option<JClass<'a>> {
+    if let Ok(class) = env.find_class(&JNIString::new(class_name)) {
         return Some(class);
     }
     let _ = env.exception_clear();
@@ -78,7 +86,7 @@ fn find_class_via_env<'a>(env: &mut JNIEnv<'a>, class_name: &str) -> Option<JCla
 
 /// [`find_class_via_application_class_loader`] loads the given class using the current application
 /// instance's class loader. When the current thread is created on the Rust side and there are no
-/// Java function frames in the current call stack, [`JNIEnv::find_class`] will use the default
+/// Java function frames in the current call stack, [`Env::find_class`] will use the default
 /// system class loader, which can't find classes other than the ones in the Java standard library
 /// or in the Android framework.
 ///
@@ -87,17 +95,19 @@ fn find_class_via_env<'a>(env: &mut JNIEnv<'a>, class_name: &str) -> Option<JCla
 ///
 /// [`Context.getClassLoader`]: https://developer.android.com/reference/android/content/Context#getClassLoader()
 fn find_class_via_application_class_loader<'a>(
-    env: &mut JNIEnv<'a>,
+    env: &mut Env<'a>,
     class_name: &str,
 ) -> Option<JClass<'a>> {
     #[allow(non_snake_case)]
-    let ActivityThread = env.find_class("android/app/ActivityThread").ok()?;
+    let ActivityThread = env
+        .find_class(jni_str!("android/app/ActivityThread"))
+        .ok()?;
 
     let current_activity_thread = env
         .call_static_method(
             ActivityThread,
-            "currentActivityThread",
-            "()Landroid/app/ActivityThread;",
+            jni_str!("currentActivityThread"),
+            jni_sig!("()Landroid/app/ActivityThread;"),
             &[],
         )
         .ok()?
@@ -107,8 +117,8 @@ fn find_class_via_application_class_loader<'a>(
     let application = env
         .call_method(
             current_activity_thread,
-            "getApplication",
-            "()Landroid/app/Application;",
+            jni_str!("getApplication"),
+            jni_sig!("()Landroid/app/Application;"),
             &[],
         )
         .ok()?
@@ -118,26 +128,28 @@ fn find_class_via_application_class_loader<'a>(
     let application_class_loader = env
         .call_method(
             application,
-            "getClassLoader",
-            "()Ljava/lang/ClassLoader;",
+            jni_str!("getClassLoader"),
+            jni_sig!("()Ljava/lang/ClassLoader;"),
             &[],
         )
         .ok()?
         .l()
         .ok()?;
 
-    Some(
-        env.call_method(
+    let class_string = env.new_string(class_name).ok()?.into();
+    let class = JValue::Object(&class_string);
+    let ret = env
+        .call_method(
             application_class_loader,
-            "loadClass",
-            "(Ljava/lang/String;)Ljava/lang/Class;",
-            &[JValue::Object(&env.new_string(class_name).ok()?.into())],
+            jni_str!("loadClass"),
+            jni_sig!("(Ljava/lang/String;)Ljava/lang/Class;"),
+            &[class],
         )
         .ok()?
         .l()
-        .ok()?
-        .into(),
-    )
+        .ok()?;
+
+    JClass::cast_local(env, ret).ok()
 }
 
 unsafe fn get_java_vm_impl() -> Option<*mut JavaVM> {

--- a/jvm-getter/Cargo.toml
+++ b/jvm-getter/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/gobley/jvm-getter"
 readme = "../README.md"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.76"
 authors = ["Chanjung Kim <chanjungkim@paxbun.dev>"]
 categories = ["no-std", "os::android-apis"]
 keywords = ["java", "jni", "android"]
@@ -18,7 +18,7 @@ goblin = { version = "0.9", default-features = false, features = [
     "elf32",
     "endian_fd",
 ], optional = true }
-jni-sys = "0.3"
+jni-sys = "0.4.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 libc = { version = "0.2", default-features = false }


### PR DESCRIPTION
## Changes

> Please describe the fixes you made in this PR.

Update the JNI dependencies to their latest versions:

- `jni-sys` to `0.4.1`.
- `jni` to `0.22.4`

Then fix the breaking API changes. It seems like the `jni` related APIs now try to be more type safe.

## Testing

> Please provide the details of the test configuration.

**Device Name**: *Xiaomi Mi 9*
**UI Version**: *crDroid 11.14 (custom ROM)*
**Android Version**: *Android 15 (API level 35)*

I ran `./gradlew allTest` and everything passed.

Then I built our project with this and updating our JNI dependencies too and ran it in a test device described above, everything seemed to work.

## Issues Fixed

> If you're going to add fixes for unreported unsupported devices, please file
> a new issue so we can discuss it in detail.

Fixes: https://github.com/gobley/jvm-getter/issues/13

---

Notes: I tried my best to adapt the existing code to the new APIs, but the JNI related code was quite new to me and I wasn't sure how to turn the existing 'return `Option` everywhere' strategy into having to return `Result` now. Let me know if you'd rather handle that differently.